### PR TITLE
FIX: multiplication in wrong spot typo

### DIFF
--- a/epicsmacrolib/_macro_src.pyx
+++ b/epicsmacrolib/_macro_src.pyx
@@ -214,7 +214,7 @@ cdef class _MacroContext:
                     string_value = (entry.rawval or b"").decode(self.string_encoding)
                     return self.expand(
                         string_value,
-                        max_length=max((1024, len(entry.rawval * 2)))
+                        max_length=max((1024, len(entry.rawval) * 2))
                     )
             entry = <MAC_ENTRY*>entry.node.previous
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* `len() * 2` and not `len( * 2)`

## Motivation and Context
conda-forge recipe is failing on this and yet it was not caught here (which is somewhat concerning?):

<details>

```
   6080 |         __pyx_t_6 = (__pyx_v_entry->rawval * 2);
        |                      ~~~~~~~~~~~~~~~~~~~~~ ^ ~
        |                                     |        |
        |                                     char*    int
  error: command '/home/conda/staged-recipes/build_artifacts/epicsmacrolib_1692647008237/_build_env/bin/x86_64-conda-linux-gnu-cc' failed with exit code 1
  error: subprocess-exited-with-error
```
</details>

## How Has This Been Tested?
To be tested on CI
