### PR TITLE
BLD: General CI build fixes

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
+        env:
+            CIBW_SKIP: pp*
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
-            CIBW_SKIP: pp*
+          CIBW_SKIP: pp*
 
       - uses: actions/upload-artifact@v4
         with:
@@ -63,7 +63,7 @@ jobs:
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
-          pattern: *artifact
+          pattern: "*artifact"
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5.0

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: cibuildwheel_artifact
+          name: ${{ matrix.os }}_cibuildwheel_artifact
 
   build_sdist:
     name: Build source distribution
@@ -63,7 +63,7 @@ jobs:
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
-          name: cibuildwheel_artifact
+          pattern: *artifact
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5.0

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: cibuildwheel_artifact
 
   build_sdist:
     name: Build source distribution
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
+          name: buildsdist_artifact
 
   upload_pypi:
     needs: [build_wheels, build_sdist]
@@ -59,7 +61,7 @@ jobs:
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
+          name: cibuildwheel_artifact
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11]
-        python-version: ["3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
* Differentiate artifact save names to avoid CI failure
* update macos runners, macos-11 no longer exists
* Only build for cpython, I don't think this was built for pypy 

## Motivation and Context
Builds are failing, and this is something I can poke at during meetings

## How Has This Been Tested?
run CI run 

## Where Has This Been Documented?
This PR